### PR TITLE
Fix `finally` function

### DIFF
--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -238,7 +238,7 @@ public extension Promise {
 
 public extension Promise {
     
-    @discardableResult public func finally<X>(block: @escaping () -> X) -> Promise<X> {
+    @discardableResult public func finally<X>(_ block: @escaping () -> X) -> Promise<X> {
         tryStartInitialPromiseAndStartIfneeded()
         let p = Promise<X>()
         switch state {


### PR DESCRIPTION
This is a really small fix that allows to use `finally` function like this:
```swift
.finally({

})
```
as well as like this:
```swift
.finally {

}
```

---

Why?
Because Xcode formats chaining blocks with trailing closures like this:
```swift
fetchUserId()
    .then { userId in
    }
    .onError { error in
    }
    .finally {
}
```
  ↑ note the last brace not indented, which I don't like,
using the `({ ... })` syntax fixes this case 😁