### PR TITLE
Recover

### DIFF
--- a/Source/Promise+BridgeError.swift
+++ b/Source/Promise+BridgeError.swift
@@ -1,0 +1,50 @@
+//
+//  Promise+BridgeError.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 24/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import Foundation
+
+public extension Promise {
+    
+    public func bridgeError(to myError: Error) -> Promise<T> {
+        return Promise<T> { resolve, reject in
+            self.then { t in
+                resolve(t)
+            }.onError { _ in
+                reject(myError)
+            }
+        }
+    }
+    
+    public func bridgeError(_ errorType: Error, to myError: Error) -> Promise<T> {
+        return Promise<T> { resolve, reject in
+            self.then { t in
+                resolve(t)
+            }.onError { e in
+                if e._code == errorType._code && e._domain == errorType._domain {
+                    reject(myError)
+                } else {
+                    reject(e)
+                }
+            }
+        }
+    }
+    
+    public func bridgeError(_ block:@escaping (Error) throws -> Void) -> Promise<T> {
+        return Promise<T> { resolve, reject in
+            self.then { t in
+                resolve(t)
+            }.onError { e in
+                do {
+                    try block(e)
+                } catch {
+                    reject(error)
+                }
+            }
+        }
+    }
+}

--- a/Source/Promise+Error.swift
+++ b/Source/Promise+Error.swift
@@ -36,4 +36,28 @@ public extension Promise {
         passAlongFirstPromiseStartFunctionAndStateTo(p)
         return p
     }
+    
+    public func bridgeError(_ block:@escaping (Error) throws -> Void) -> Promise<T> {
+        return Promise<T> { resolve, reject in
+            self.then { t in
+                resolve(t)
+            }.onError { e in
+                do {
+                    try block(e)
+                } catch {
+                    reject(error)
+                }
+            }
+        }
+    }
+    
+    public func bridgeError(to myError: Error) -> Promise<T> {
+        return Promise<T> { resolve, reject in
+            self.then { t in
+                resolve(t)
+            }.onError { _ in
+                reject(myError)
+            }
+        }
+    }
 }

--- a/Source/Promise+Error.swift
+++ b/Source/Promise+Error.swift
@@ -36,28 +36,4 @@ public extension Promise {
         passAlongFirstPromiseStartFunctionAndStateTo(p)
         return p
     }
-    
-    public func bridgeError(_ block:@escaping (Error) throws -> Void) -> Promise<T> {
-        return Promise<T> { resolve, reject in
-            self.then { t in
-                resolve(t)
-            }.onError { e in
-                do {
-                    try block(e)
-                } catch {
-                    reject(error)
-                }
-            }
-        }
-    }
-    
-    public func bridgeError(to myError: Error) -> Promise<T> {
-        return Promise<T> { resolve, reject in
-            self.then { t in
-                resolve(t)
-            }.onError { _ in
-                reject(myError)
-            }
-        }
-    }
 }

--- a/Source/Promise+Recover.swift
+++ b/Source/Promise+Recover.swift
@@ -21,12 +21,15 @@ extension Promise {
     }
     
     public func recover(_ errorType: Error, with value: T) -> Promise<T> {
-        // TODO Find a way to compare two Error types for equality
-        return Promise { resolve, _ in
+        return Promise { resolve, reject in
             self.then { t in
                 resolve(t)
-            }.onError { _ in
-                resolve(value)
+            }.onError { e in
+                if e._code == errorType._code && e._domain == errorType._domain {
+                    resolve(value)
+                } else {
+                    reject(e)
+                }
             }
         }
     }

--- a/Source/Promise+Recover.swift
+++ b/Source/Promise+Recover.swift
@@ -1,0 +1,34 @@
+//
+//  Promise+Recover.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 22/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import Foundation
+
+extension Promise {
+    public func recover(with value: T) -> Promise<T> {
+        return Promise { resolve, _ in
+            self.then { t in
+                resolve(t)
+            }.onError { _ in
+                resolve(value)
+            }
+        }
+    }
+    
+    public func recover(_ block:@escaping (Error) -> Promise<T>) -> Promise<T> {
+        return Promise<T> { resolve, _ in
+            self.then { t in
+                resolve(t)
+            }.onError { e in
+                let p = block(e)
+                p.then { t in
+                    resolve(t)
+                }
+            }
+        }
+    }
+}

--- a/then.xcodeproj/project.pbxproj
+++ b/then.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		99B29F7F1E5D688900CF8E98 /* RaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7E1E5D688900CF8E98 /* RaceTests.swift */; };
 		99B29F811E5D6E0F00CF8E98 /* Promise+Retry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */; };
 		99B29F831E5D6F5500CF8E98 /* RetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F821E5D6F5500CF8E98 /* RetryTests.swift */; };
+		99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */; };
+		99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F761E5D590D00CF8E98 /* RecoverTests.swift */; };
 		99B5ACA21C66831C005CDA28 /* then.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B5AC971C66831C005CDA28 /* then.framework */; };
 		99B5ACA71C66831C005CDA28 /* ThenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B5ACA61C66831C005CDA28 /* ThenTests.swift */; };
 		99E3CB071E5EA53900FEF11A /* PromiseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E3CB061E5EA53900FEF11A /* PromiseError.swift */; };
@@ -65,6 +67,8 @@
 		99B29F7E1E5D688900CF8E98 /* RaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaceTests.swift; sourceTree = "<group>"; };
 		99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Retry.swift"; sourceTree = "<group>"; };
 		99B29F821E5D6F5500CF8E98 /* RetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryTests.swift; sourceTree = "<group>"; };
+		99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Recover.swift"; sourceTree = "<group>"; };
+		99B29F761E5D590D00CF8E98 /* RecoverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoverTests.swift; sourceTree = "<group>"; };
 		99B5AC971C66831C005CDA28 /* then.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = then.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA11C66831C005CDA28 /* thenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = thenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA61C66831C005CDA28 /* ThenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThenTests.swift; sourceTree = "<group>"; };
@@ -153,6 +157,7 @@
 				99B29F821E5D6F5500CF8E98 /* RetryTests.swift */,
 				99B29F7E1E5D688900CF8E98 /* RaceTests.swift */,
 				99B29F7A1E5D5F4900CF8E98 /* ValidateTests.swift */,
+				99B29F761E5D590D00CF8E98 /* RecoverTests.swift */,
 				9962ADC51D585A06005769CD /* Helpers.swift */,
 				99B5ACA81C66831C005CDA28 /* Info.plist */,
 			);
@@ -197,6 +202,7 @@
 				99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */,
 				99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */,
 				99B29F781E5D5F3400CF8E98 /* Promise+Validate.swift */,
+				99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */,
 				99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */,
 				99FC637E1C86085C008C1155 /* then.h */,
 			);
@@ -380,6 +386,7 @@
 				99B29F811E5D6E0F00CF8E98 /* Promise+Retry.swift in Sources */,
 				99FA2C661E5B1B8100CA3959 /* PromiseType.swift in Sources */,
 				99FC63801C86085C008C1155 /* Promise.swift in Sources */,
+				99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */,
 				99FA2C641E5B022D00CA3959 /* Promise+Finally.swift in Sources */,
 				99AA1C711CB7DDF800ADA4C3 /* WhenAll.swift in Sources */,
 				99255A4D1DC119B500D9FC72 /* PromiseBlocks.swift in Sources */,
@@ -392,6 +399,7 @@
 			files = (
 				9962ADC21D585902005769CD /* ProgressTests.swift in Sources */,
 				99B29F7B1E5D5F4900CF8E98 /* ValidateTests.swift in Sources */,
+				99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */,
 				9962ADCA1D585E12005769CD /* RegisterThenTests.swift in Sources */,
 				99B29F7F1E5D688900CF8E98 /* RaceTests.swift in Sources */,
 				9962ADC81D585B00005769CD /* OnErrorTests.swift in Sources */,

--- a/then.xcodeproj/project.pbxproj
+++ b/then.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		991E114F1E600D0700448085 /* Promise+BridgeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E114E1E600D0700448085 /* Promise+BridgeError.swift */; };
+		991E11511E600D3900448085 /* BridgeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E11501E600D3900448085 /* BridgeErrorTests.swift */; };
 		99255A4D1DC119B500D9FC72 /* PromiseBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */; };
 		9962ADC21D585902005769CD /* ProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADC11D585902005769CD /* ProgressTests.swift */; };
 		9962ADC41D5859CC005769CD /* WhenAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADC31D5859CC005769CD /* WhenAllTests.swift */; };
@@ -15,14 +17,14 @@
 		9962ADCA1D585E12005769CD /* RegisterThenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADC91D585E12005769CD /* RegisterThenTests.swift */; };
 		9962ADCD1D586155005769CD /* PromiseState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADCB1D58610E005769CD /* PromiseState.swift */; };
 		99AA1C711CB7DDF800ADA4C3 /* WhenAll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */; };
+		99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */; };
+		99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F761E5D590D00CF8E98 /* RecoverTests.swift */; };
 		99B29F791E5D5F3400CF8E98 /* Promise+Validate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F781E5D5F3400CF8E98 /* Promise+Validate.swift */; };
 		99B29F7B1E5D5F4900CF8E98 /* ValidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7A1E5D5F4900CF8E98 /* ValidateTests.swift */; };
 		99B29F7D1E5D687F00CF8E98 /* Promise+Race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */; };
 		99B29F7F1E5D688900CF8E98 /* RaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7E1E5D688900CF8E98 /* RaceTests.swift */; };
 		99B29F811E5D6E0F00CF8E98 /* Promise+Retry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */; };
 		99B29F831E5D6F5500CF8E98 /* RetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F821E5D6F5500CF8E98 /* RetryTests.swift */; };
-		99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */; };
-		99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F761E5D590D00CF8E98 /* RecoverTests.swift */; };
 		99B5ACA21C66831C005CDA28 /* then.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B5AC971C66831C005CDA28 /* then.framework */; };
 		99B5ACA71C66831C005CDA28 /* ThenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B5ACA61C66831C005CDA28 /* ThenTests.swift */; };
 		99E3CB071E5EA53900FEF11A /* PromiseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E3CB061E5EA53900FEF11A /* PromiseError.swift */; };
@@ -53,6 +55,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		991E114E1E600D0700448085 /* Promise+BridgeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+BridgeError.swift"; sourceTree = "<group>"; };
+		991E11501E600D3900448085 /* BridgeErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BridgeErrorTests.swift; sourceTree = "<group>"; };
 		99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseBlocks.swift; sourceTree = "<group>"; };
 		9962ADC11D585902005769CD /* ProgressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressTests.swift; sourceTree = "<group>"; };
 		9962ADC31D5859CC005769CD /* WhenAllTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhenAllTests.swift; sourceTree = "<group>"; };
@@ -61,14 +65,14 @@
 		9962ADC91D585E12005769CD /* RegisterThenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegisterThenTests.swift; sourceTree = "<group>"; };
 		9962ADCB1D58610E005769CD /* PromiseState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseState.swift; sourceTree = "<group>"; };
 		99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhenAll.swift; sourceTree = "<group>"; };
+		99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Recover.swift"; sourceTree = "<group>"; };
+		99B29F761E5D590D00CF8E98 /* RecoverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoverTests.swift; sourceTree = "<group>"; };
 		99B29F781E5D5F3400CF8E98 /* Promise+Validate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Validate.swift"; sourceTree = "<group>"; };
 		99B29F7A1E5D5F4900CF8E98 /* ValidateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidateTests.swift; sourceTree = "<group>"; };
 		99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Race.swift"; sourceTree = "<group>"; };
 		99B29F7E1E5D688900CF8E98 /* RaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaceTests.swift; sourceTree = "<group>"; };
 		99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Retry.swift"; sourceTree = "<group>"; };
 		99B29F821E5D6F5500CF8E98 /* RetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryTests.swift; sourceTree = "<group>"; };
-		99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Recover.swift"; sourceTree = "<group>"; };
-		99B29F761E5D590D00CF8E98 /* RecoverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecoverTests.swift; sourceTree = "<group>"; };
 		99B5AC971C66831C005CDA28 /* then.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = then.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA11C66831C005CDA28 /* thenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = thenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA61C66831C005CDA28 /* ThenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThenTests.swift; sourceTree = "<group>"; };
@@ -158,6 +162,7 @@
 				99B29F7E1E5D688900CF8E98 /* RaceTests.swift */,
 				99B29F7A1E5D5F4900CF8E98 /* ValidateTests.swift */,
 				99B29F761E5D590D00CF8E98 /* RecoverTests.swift */,
+				991E11501E600D3900448085 /* BridgeErrorTests.swift */,
 				9962ADC51D585A06005769CD /* Helpers.swift */,
 				99B5ACA81C66831C005CDA28 /* Info.plist */,
 			);
@@ -203,6 +208,7 @@
 				99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */,
 				99B29F781E5D5F3400CF8E98 /* Promise+Validate.swift */,
 				99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */,
+				991E114E1E600D0700448085 /* Promise+BridgeError.swift */,
 				99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */,
 				99FC637E1C86085C008C1155 /* then.h */,
 			);
@@ -385,6 +391,7 @@
 				99FA2C6A1E5B1F2B00CA3959 /* Promise+Error.swift in Sources */,
 				99B29F811E5D6E0F00CF8E98 /* Promise+Retry.swift in Sources */,
 				99FA2C661E5B1B8100CA3959 /* PromiseType.swift in Sources */,
+				991E114F1E600D0700448085 /* Promise+BridgeError.swift in Sources */,
 				99FC63801C86085C008C1155 /* Promise.swift in Sources */,
 				99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */,
 				99FA2C641E5B022D00CA3959 /* Promise+Finally.swift in Sources */,
@@ -397,6 +404,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				991E11511E600D3900448085 /* BridgeErrorTests.swift in Sources */,
 				9962ADC21D585902005769CD /* ProgressTests.swift in Sources */,
 				99B29F7B1E5D5F4900CF8E98 /* ValidateTests.swift in Sources */,
 				99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */,

--- a/thenTests/BridgeErrorTests.swift
+++ b/thenTests/BridgeErrorTests.swift
@@ -1,0 +1,96 @@
+//
+//  BridgeErrorTests.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 24/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import XCTest
+import then
+
+class BridgeErrorTests: XCTestCase {
+    
+    func testBridgeAllErrorsToMine() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .bridgeError(to: MyError.defaultError)
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeAllErrorsNoError() {
+        let exp = expectation(description: "")
+        Promise<Int>.resolve(42)
+            .bridgeError(to: MyError.defaultError)
+            .then { _ in
+                exp.fulfill()
+            }.onError { _ in
+                XCTFail("onError shouldn't be called")
+
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeASpecificErrorToMine() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject(PromiseError.retryInvalidInput)
+            .bridgeError(PromiseError.retryInvalidInput, to: MyError.defaultError)
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeASpecificErrorToMineNotMatchingError() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject(PromiseError.default)
+            .bridgeError(PromiseError.retryInvalidInput, to: MyError.defaultError)
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? PromiseError {
+                    XCTAssertTrue(e == .default)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeErrorCanUseBlockAndThrow() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .bridgeError { _ in
+                throw MyError.defaultError
+            }
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/thenTests/RecoverTests.swift
+++ b/thenTests/RecoverTests.swift
@@ -36,12 +36,117 @@ class RecoverTests: XCTestCase {
     func testRecoverWithPromise() {
         let e = expectation(description: "")
         Promise<Int>.reject()
-            .recover { _ in
-                return Promise.resolve(56)
-            }
+            .recover(with: Promise<Int>.resolve(56))
             .then { s in
                 XCTAssertEqual(s, 56)
                 e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverWithFailablePromise() {
+        let e = expectation(description: "")
+        Promise<Int>.reject()
+            .recover(with: Promise<Int>.reject())
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }
+            .onError { _ in
+                e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverCanUseABlock() {
+        let e = expectation(description: "")
+        Promise<Int>.reject()
+            .recover { _ in
+                return 32
+            }
+            .then { s in
+                XCTAssertEqual(s, 32)
+                e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverCanThrowANewError() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .recover { e in
+                if let e = e as? PromiseError, e == .default {
+                    throw MyError.defaultError
+                }
+                return 32
+            } .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeError() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .bridgeError { _ in
+                throw MyError.defaultError
+            }
+           .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testBridgeError2() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .bridgeError(to: MyError.defaultError)
+            .then { _ in
+                XCTFail("then shouldn't be called")
+            }.onError { e in
+                if let e = e as? MyError {
+                    XCTAssertTrue(e == .defaultError)
+                } else {
+                    XCTFail()
+                }
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverForSpecificError() {
+        let exp = expectation(description: "")
+        Promise<Int>.resolve(10)
+            .validate { $0 > 100 }
+            .recover(PromiseError.validationFailed, with: 123)
+            .then { i in
+                XCTAssertEqual(i, 123)
+                exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverForSpecificErrorDoesNotRecoverWhenTypeNotMatching() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject()
+            .recover(PromiseError.validationFailed, with: 123)
+            .then { _ in
+                XCTFail()
+        }.onError { _ in
+            exp.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
     }

--- a/thenTests/RecoverTests.swift
+++ b/thenTests/RecoverTests.swift
@@ -114,4 +114,20 @@ class RecoverTests: XCTestCase {
         }
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testEquatableError() {
+        let exp = expectation(description: "")
+        Promise<Int>.reject(SomeError())
+            .recover(SomeError(), with: 123)
+            .then { _ in
+                exp.fulfill()
+            }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}
+
+struct SomeError: Error { }
+extension SomeError :Equatable { }
+func == (lhs: SomeError, rhs: SomeError) -> Bool {
+    return true
 }

--- a/thenTests/RecoverTests.swift
+++ b/thenTests/RecoverTests.swift
@@ -91,42 +91,6 @@ class RecoverTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testBridgeError() {
-        let exp = expectation(description: "")
-        Promise<Int>.reject()
-            .bridgeError { _ in
-                throw MyError.defaultError
-            }
-           .then { _ in
-                XCTFail("then shouldn't be called")
-            }.onError { e in
-                if let e = e as? MyError {
-                    XCTAssertTrue(e == .defaultError)
-                } else {
-                    XCTFail()
-                }
-                exp.fulfill()
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-    }
-    
-    func testBridgeError2() {
-        let exp = expectation(description: "")
-        Promise<Int>.reject()
-            .bridgeError(to: MyError.defaultError)
-            .then { _ in
-                XCTFail("then shouldn't be called")
-            }.onError { e in
-                if let e = e as? MyError {
-                    XCTAssertTrue(e == .defaultError)
-                } else {
-                    XCTFail()
-                }
-                exp.fulfill()
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-    }
-    
     func testRecoverForSpecificError() {
         let exp = expectation(description: "")
         Promise<Int>.resolve(10)

--- a/thenTests/RecoverTests.swift
+++ b/thenTests/RecoverTests.swift
@@ -1,0 +1,48 @@
+//
+//  RecoverTests.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 22/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import XCTest
+import then
+
+class RecoverTests: XCTestCase {
+    
+    func testRecoverWithString() {
+        let e = expectation(description: "")
+        Promise<String>.reject()
+            .recover(with: "Banana")
+            .then { s in
+                XCTAssertEqual(s, "Banana")
+                e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverWithInt() {
+        let e = expectation(description: "")
+        Promise<Int>.reject()
+            .recover(with: 12)
+            .then { s in
+                XCTAssertEqual(s, 12)
+                e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRecoverWithPromise() {
+        let e = expectation(description: "")
+        Promise<Int>.reject()
+            .recover { _ in
+                return Promise.resolve(56)
+            }
+            .then { s in
+                XCTAssertEqual(s, 56)
+                e.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}


### PR DESCRIPTION
Enable to `.recover()` a failed Promise with a default value or another Promise

```swift
Promise<Int>.reject()
  .recover(with: 12)
  .then { s in
    // s == 12
  }

Promise<String>.reject()
  .recover { e in
    return Promise.resolve("NeverMind")
  }.then { s in
  // s == NeverMind
  }
```