### PR TITLE
Race/Any

### DIFF
--- a/Source/Promise+Race.swift
+++ b/Source/Promise+Race.swift
@@ -9,14 +9,6 @@
 import Foundation
 
 public func race<T>(_ promises: Promise<T>...) -> Promise<T> {
-    return race(promises)
-}
-
-public func any<T>(_ promises: Promise<T>...) -> Promise<T> {
-    return race(promises)
-}
-
-private func race<T>(_ promises: [Promise<T>]) -> Promise<T> {
     return Promise { resolve, reject in
         var done = false
         var errorCount = 0

--- a/Source/Promise+Race.swift
+++ b/Source/Promise+Race.swift
@@ -1,0 +1,37 @@
+//
+//  Promise+Race.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 22/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import Foundation
+
+public func race<T>(_ promises: Promise<T>...) -> Promise<T> {
+    return race(promises)
+}
+
+public func any<T>(_ promises: Promise<T>...) -> Promise<T> {
+    return race(promises)
+}
+
+private func race<T>(_ promises: [Promise<T>]) -> Promise<T> {
+    return Promise { resolve, reject in
+        var done = false
+        var errorCount = 0
+        for p in promises {
+            p.then { t in
+                if !done {
+                    resolve(t)
+                    done = true
+                }
+            }.onError { _ in
+                errorCount += 1
+                if errorCount == promises.count {
+                    reject(PromiseDefaultError())
+                }
+            }
+        }
+    }
+}

--- a/then.xcodeproj/project.pbxproj
+++ b/then.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		99AA1C711CB7DDF800ADA4C3 /* WhenAll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */; };
 		99B29F811E5D6E0F00CF8E98 /* Promise+Retry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */; };
 		99B29F831E5D6F5500CF8E98 /* RetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F821E5D6F5500CF8E98 /* RetryTests.swift */; };
+		99B29F7D1E5D687F00CF8E98 /* Promise+Race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */; };
+		99B29F7F1E5D688900CF8E98 /* RaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B29F7E1E5D688900CF8E98 /* RaceTests.swift */; };
 		99B5ACA21C66831C005CDA28 /* then.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99B5AC971C66831C005CDA28 /* then.framework */; };
 		99B5ACA71C66831C005CDA28 /* ThenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B5ACA61C66831C005CDA28 /* ThenTests.swift */; };
 		99E4FA0E1E49B59A00E6F10C /* PromiseBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */; };
@@ -56,6 +58,8 @@
 		99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhenAll.swift; sourceTree = "<group>"; };
 		99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Retry.swift"; sourceTree = "<group>"; };
 		99B29F821E5D6F5500CF8E98 /* RetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryTests.swift; sourceTree = "<group>"; };
+		99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Race.swift"; sourceTree = "<group>"; };
+		99B29F7E1E5D688900CF8E98 /* RaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaceTests.swift; sourceTree = "<group>"; };
 		99B5AC971C66831C005CDA28 /* then.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = then.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA11C66831C005CDA28 /* thenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = thenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA61C66831C005CDA28 /* ThenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThenTests.swift; sourceTree = "<group>"; };
@@ -141,6 +145,7 @@
 				9962ADC71D585B00005769CD /* OnErrorTests.swift */,
 				9962ADC31D5859CC005769CD /* WhenAllTests.swift */,
 				99B29F821E5D6F5500CF8E98 /* RetryTests.swift */,
+				99B29F7E1E5D688900CF8E98 /* RaceTests.swift */,
 				9962ADC51D585A06005769CD /* Helpers.swift */,
 				99B5ACA81C66831C005CDA28 /* Info.plist */,
 			);
@@ -182,6 +187,7 @@
 				99FA2C6B1E5B20BB00CA3959 /* Promise+Aliases.swift */,
 				99FA2C6D1E5B20EA00CA3959 /* Promise+Helpers.swift */,
 				99B29F801E5D6E0F00CF8E98 /* Promise+Retry.swift */,
+				99B29F7C1E5D687F00CF8E98 /* Promise+Race.swift */,
 				99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */,
 				99FC637E1C86085C008C1155 /* then.h */,
 			);
@@ -355,6 +361,7 @@
 			files = (
 				99FA2C681E5B1C2F00CA3959 /* Promise+Progress.swift in Sources */,
 				99FA2C6C1E5B20BB00CA3959 /* Promise+Aliases.swift in Sources */,
+				99B29F7D1E5D687F00CF8E98 /* Promise+Race.swift in Sources */,
 				9962ADCD1D586155005769CD /* PromiseState.swift in Sources */,
 				99FA2C6E1E5B20EA00CA3959 /* Promise+Helpers.swift in Sources */,
 				99FA2C701E5B212900CA3959 /* Promise+Then.swift in Sources */,
@@ -374,6 +381,7 @@
 			files = (
 				9962ADC21D585902005769CD /* ProgressTests.swift in Sources */,
 				9962ADCA1D585E12005769CD /* RegisterThenTests.swift in Sources */,
+				99B29F7F1E5D688900CF8E98 /* RaceTests.swift in Sources */,
 				9962ADC81D585B00005769CD /* OnErrorTests.swift in Sources */,
 				99B29F831E5D6F5500CF8E98 /* RetryTests.swift in Sources */,
 				99B5ACA71C66831C005CDA28 /* ThenTests.swift in Sources */,

--- a/thenTests/RaceTests.swift
+++ b/thenTests/RaceTests.swift
@@ -1,0 +1,60 @@
+//
+//  RaceTests.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 22/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import XCTest
+import then
+
+class RaceTests: XCTestCase {
+    
+    func testRaceFirstArrivesFirst() {
+        let e = expectation(description: "")
+        let p1 = Promise<String> { r, _ in
+            wait(1) {
+                r("1")
+            }
+        }
+        let p2 = Promise<String> { r, _ in
+            wait(2) {
+                r("2")
+            }
+        }
+        race(p1, p2).then { s in
+            e.fulfill()
+            XCTAssertEqual(s, "1")
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    func testRaceWithOneFailing() {
+        let e = expectation(description: "")
+        let p1 = Promise<String>.reject()
+        let p2 = Promise<String> { r, _ in
+            wait(2) {
+                r("2")
+            }
+        }
+        race(p1, p2).then { s in
+            e.fulfill()
+            XCTAssertEqual(s, "2")
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    func testRaceFailsIfAllFail() {
+        let e = expectation(description: "")
+        let p1 = Promise<String>.reject()
+        let p2 = Promise<String>.reject()
+        race(p1, p2).then { _ in
+            XCTFail()
+        }.onError { _ in
+            e.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+}


### PR DESCRIPTION
Adds `race`/ `any` to help with concurrency.


```swift
race(task1, task2, task3).then { work in
  // The first result !
}
```

I think it's an interresting approach to add both `race` and `any` since both keywords are usually used and we want to leave the choice to users :)