### PR TITLE
NoMatterWhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Async code is now **concise**, **flexible** and **maintainable** ❤️
 - [x] Pure Swift & Lightweight
 - [x] Chainable
 - [x] Progress support
-- [x] Common Promise helpers: `race`, `recover` `validate` `retry` `bridgeError` `chain` ...
+- [x] Common Promise helpers: `race`, `recover` `validate` `retry` `bridgeError` `chain` `noMatterWhat` ...
 
 
 ## Example
@@ -118,6 +118,7 @@ Mental sanity saved
   5. [bridgeError](#bridgeError)
   6. [whenAll](#whenAll)
   7. [chain](#chain)
+  8. [noMatterWhat](#nomatterwhat)
 6. [Async](#async)
 
 
@@ -288,6 +289,24 @@ extension Photo {
     }
 }
 ```
+
+#### NoMatterWhat
+
+With `noMatterWhat` you can add code to be executed in the middle of a promise chain, no matter what happens.
+
+```swift
+func fetchNext() -> Promise<[T]> {
+    isLoading = true
+    call.params["page"] = page + 1
+    return call.fetch()
+        .registerThen(parseResponse)
+        .resolveOnMainThread()
+        .noMatterWhat {
+            self.isLoading = false
+    }
+}
+```
+
 
 ### Async
 `AsyncTask` and `Async<T>` typealisases are provided for those of us who think that Async can be clearer than `Promise`.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ fetchUsers.then { users in
     // YAY
 }
 ```
+Note that `onError` and `finally` also have their non-starting counterparts : `registerOnError` and `registerFinally`.
 
 ### Returning a rejecting promise
 

--- a/Source/Promise+Error.swift
+++ b/Source/Promise+Error.swift
@@ -12,6 +12,10 @@ public extension Promise {
     
     @discardableResult public func onError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
         tryStartInitialPromiseAndStartIfneeded()
+        return registerOnError(block)
+    }
+    
+    @discardableResult public func registerOnError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
         let p = Promise<Void>()
         switch state {
         case .fulfilled:

--- a/Source/Promise+Finally.swift
+++ b/Source/Promise+Finally.swift
@@ -12,6 +12,10 @@ public extension Promise {
     
     @discardableResult public func finally<X>(_ block: @escaping () -> X) -> Promise<X> {
         tryStartInitialPromiseAndStartIfneeded()
+        return registerFinally(block)
+    }
+    
+    @discardableResult public func registerFinally<X>(_ block: @escaping () -> X) -> Promise<X> {
         let p = Promise<X>()
         switch state {
         case .fulfilled:

--- a/Source/Promise+NoMatterWhat.swift
+++ b/Source/Promise+NoMatterWhat.swift
@@ -1,0 +1,24 @@
+//
+//  Promise+NoMatterWhat.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 24/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import Foundation
+
+extension Promise {
+
+    public func noMatterWhat(_ block: @escaping () -> Void) -> Promise<T> {
+        return Promise { resolve, reject in
+            self.then { result in
+                block()
+                resolve(result)
+            }.onError { error in
+                block()
+                reject(error)
+            }
+        }
+    }
+}

--- a/then.xcodeproj/project.pbxproj
+++ b/then.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		9907A5E21E76EBC100826BBE /* Promise+Chain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9907A5DE1E76EBAE00826BBE /* Promise+Chain.swift */; };
 		991E114F1E600D0700448085 /* Promise+BridgeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E114E1E600D0700448085 /* Promise+BridgeError.swift */; };
 		991E11511E600D3900448085 /* BridgeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E11501E600D3900448085 /* BridgeErrorTests.swift */; };
+		991E11551E6016A000448085 /* NoMatterWhatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E11541E6016A000448085 /* NoMatterWhatTests.swift */; };
+		991E11581E60173400448085 /* Promise+NoMatterWhat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991E11561E6016AD00448085 /* Promise+NoMatterWhat.swift */; };
 		99255A4D1DC119B500D9FC72 /* PromiseBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */; };
 		9962ADC21D585902005769CD /* ProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADC11D585902005769CD /* ProgressTests.swift */; };
 		9962ADC41D5859CC005769CD /* WhenAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9962ADC31D5859CC005769CD /* WhenAllTests.swift */; };
@@ -43,6 +45,7 @@
 		99DF353F1E66A473005FD22F /* Promise+Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA2C671E5B1C2F00CA3959 /* Promise+Progress.swift */; };
 		99DF35401E66A47A005FD22F /* PromiseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E3CB061E5EA53900FEF11A /* PromiseError.swift */; };
 		99DF35411E66A481005FD22F /* PromiseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA2C651E5B1B8100CA3959 /* PromiseType.swift */; };
+		99B9FA8F1E5F107400D522C8 /* FinallyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B9FA8E1E5F107400D522C8 /* FinallyTests.swift */; };
 		99E3CB071E5EA53900FEF11A /* PromiseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E3CB061E5EA53900FEF11A /* PromiseError.swift */; };
 		99E4FA0E1E49B59A00E6F10C /* PromiseBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */; };
 		99FA2C641E5B022D00CA3959 /* Promise+Finally.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FA2C631E5B022D00CA3959 /* Promise+Finally.swift */; };
@@ -75,6 +78,8 @@
 		9907A5E01E76EBBD00826BBE /* ChainTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChainTests.swift; sourceTree = "<group>"; };
 		991E114E1E600D0700448085 /* Promise+BridgeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+BridgeError.swift"; sourceTree = "<group>"; };
 		991E11501E600D3900448085 /* BridgeErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BridgeErrorTests.swift; sourceTree = "<group>"; };
+		991E11541E6016A000448085 /* NoMatterWhatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoMatterWhatTests.swift; sourceTree = "<group>"; };
+		991E11561E6016AD00448085 /* Promise+NoMatterWhat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+NoMatterWhat.swift"; sourceTree = "<group>"; };
 		99255A4C1DC119B500D9FC72 /* PromiseBlocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseBlocks.swift; sourceTree = "<group>"; };
 		9962ADC11D585902005769CD /* ProgressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressTests.swift; sourceTree = "<group>"; };
 		9962ADC31D5859CC005769CD /* WhenAllTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhenAllTests.swift; sourceTree = "<group>"; };
@@ -95,6 +100,7 @@
 		99B5ACA11C66831C005CDA28 /* thenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = thenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		99B5ACA61C66831C005CDA28 /* ThenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThenTests.swift; sourceTree = "<group>"; };
 		99B5ACA81C66831C005CDA28 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		99B9FA8E1E5F107400D522C8 /* FinallyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FinallyTests.swift; sourceTree = "<group>"; };
 		99E3CB061E5EA53900FEF11A /* PromiseError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseError.swift; sourceTree = "<group>"; };
 		99FA2C631E5B022D00CA3959 /* Promise+Finally.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Finally.swift"; sourceTree = "<group>"; };
 		99FA2C651E5B1B8100CA3959 /* PromiseType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseType.swift; sourceTree = "<group>"; };
@@ -175,6 +181,7 @@
 				9962ADC91D585E12005769CD /* RegisterThenTests.swift */,
 				9962ADC11D585902005769CD /* ProgressTests.swift */,
 				9962ADC71D585B00005769CD /* OnErrorTests.swift */,
+				99B9FA8E1E5F107400D522C8 /* FinallyTests.swift */,
 				9962ADC31D5859CC005769CD /* WhenAllTests.swift */,
 				99B29F821E5D6F5500CF8E98 /* RetryTests.swift */,
 				99B29F7E1E5D688900CF8E98 /* RaceTests.swift */,
@@ -182,6 +189,7 @@
 				99B29F761E5D590D00CF8E98 /* RecoverTests.swift */,
 				991E11501E600D3900448085 /* BridgeErrorTests.swift */,
 				9907A5E01E76EBBD00826BBE /* ChainTests.swift */,
+				991E11541E6016A000448085 /* NoMatterWhatTests.swift */,
 				9962ADC51D585A06005769CD /* Helpers.swift */,
 				99B5ACA81C66831C005CDA28 /* Info.plist */,
 			);
@@ -229,6 +237,7 @@
 				99B29F721E5D58C600CF8E98 /* Promise+Recover.swift */,
 				991E114E1E600D0700448085 /* Promise+BridgeError.swift */,
 				9907A5DE1E76EBAE00826BBE /* Promise+Chain.swift */,
+				991E11561E6016AD00448085 /* Promise+NoMatterWhat.swift */,
 				99AA1C701CB7DDF800ADA4C3 /* WhenAll.swift */,
 				99FC637E1C86085C008C1155 /* then.h */,
 			);
@@ -416,6 +425,7 @@
 				99FC63801C86085C008C1155 /* Promise.swift in Sources */,
 				99B29F731E5D58C600CF8E98 /* Promise+Recover.swift in Sources */,
 				99FA2C641E5B022D00CA3959 /* Promise+Finally.swift in Sources */,
+				991E11581E60173400448085 /* Promise+NoMatterWhat.swift in Sources */,
 				99AA1C711CB7DDF800ADA4C3 /* WhenAll.swift in Sources */,
 				99255A4D1DC119B500D9FC72 /* PromiseBlocks.swift in Sources */,
 			);
@@ -427,6 +437,8 @@
 			files = (
 				991E11511E600D3900448085 /* BridgeErrorTests.swift in Sources */,
 				9962ADC21D585902005769CD /* ProgressTests.swift in Sources */,
+				99B9FA8F1E5F107400D522C8 /* FinallyTests.swift in Sources */,
+				991E11551E6016A000448085 /* NoMatterWhatTests.swift in Sources */,
 				99B29F7B1E5D5F4900CF8E98 /* ValidateTests.swift in Sources */,
 				99B29F771E5D590D00CF8E98 /* RecoverTests.swift in Sources */,
 				9962ADCA1D585E12005769CD /* RegisterThenTests.swift in Sources */,

--- a/thenTests/FinallyTests.swift
+++ b/thenTests/FinallyTests.swift
@@ -39,4 +39,25 @@ class FinallyTests: XCTestCase {
         }
         waitForExpectations(timeout: 2, handler: nil)
     }
+    
+    func testRegisterFinallyDoesntStartThePromise() {
+        let exp = expectation(description: "error block called")
+        syncRejectionPromise().registerFinally {
+             XCTFail()
+        }
+        wait(1) {
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRegisterFinally() {
+        let exp = expectation(description: "error block called")
+        let p = syncRejectionPromise()
+        p.registerFinally {
+            exp.fulfill()
+        }
+        p.start()
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 }

--- a/thenTests/FinallyTests.swift
+++ b/thenTests/FinallyTests.swift
@@ -1,0 +1,42 @@
+//
+//  FinallyTests.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 23/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import XCTest
+import then
+
+class FinallyTests: XCTestCase {
+    
+    func testFinallyCalledWhenSynchronous() {
+        let finallyblock = expectation(description: "error block called")
+        syncRejectionPromise().finally {
+            finallyblock.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testMultipleFinallyBlockCanBeRegisteredOnSamePromise() {
+        let finally1 = expectation(description: "finally called")
+        let finally2 = expectation(description: "finally called")
+        let finally3 = expectation(description: "finally called")
+        let finally4 = expectation(description: "finally called")
+        let p = failingFetchUserFollowStatusFromName("")
+        p.finally {
+            finally1.fulfill()
+        }
+        p.finally {
+            finally2.fulfill()
+        }
+        p.finally {
+            finally3.fulfill()
+        }
+        p.finally {
+            finally4.fulfill()
+        }
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+}

--- a/thenTests/NoMatterWhatTests.swift
+++ b/thenTests/NoMatterWhatTests.swift
@@ -1,0 +1,39 @@
+//
+//  NoMatterWhatTests.swift
+//  then
+//
+//  Created by Sacha Durand Saint Omer on 24/02/2017.
+//  Copyright © 2017 s4cha. All rights reserved.
+//
+
+import XCTest
+import then
+
+class NoMatterWhatTests: XCTestCase {
+    
+    func testNoMatterWhatCalledOnSuccess() {
+        let exp = expectation(description: "")
+        var isLoading = true
+        XCTAssertTrue(isLoading)
+        Promise<String>.resolve("Cool").noMatterWhat {
+            isLoading = false
+        }.finally {
+            XCTAssertFalse(isLoading)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testNoMatterWhatCalledOnError() {
+        let exp = expectation(description: "")
+        var isLoading = true
+        XCTAssertTrue(isLoading)
+        Promise<String>.reject().noMatterWhat {
+            isLoading = false
+        }.finally {
+            XCTAssertFalse(isLoading)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/thenTests/OnErrorTests.swift
+++ b/thenTests/OnErrorTests.swift
@@ -110,5 +110,25 @@ class OnErrorTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-
+    
+    func testRegisterOnErrorDoesntStartThePromise() {
+        let exp = expectation(description: "error block called")
+        syncRejectionPromise().registerOnError { _ in
+            XCTFail()
+        }
+        wait(1) {
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
+    func testRegisterOnError() {
+        let exp = expectation(description: "error block called")
+        let p = syncRejectionPromise()
+        p.registerOnError { _ in
+            exp.fulfill()
+        }
+        p.start()
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 }

--- a/thenTests/ThenTests.swift
+++ b/thenTests/ThenTests.swift
@@ -86,14 +86,6 @@ class ThenTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testFinallyCalledWhenSynchronous() {
-        let finallyblock = expectation(description: "error block called")
-        syncRejectionPromise().finally {
-            finallyblock.fulfill()
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-    }
-    
     func testClassicThenLaunchesPromise() {
         let thenExpectation = expectation(description: "then called")
         fetchUserId().then { id in
@@ -120,27 +112,6 @@ class ThenTests: XCTestCase {
         }
         p.then { _ in
             then4.fulfill()
-        }
-        waitForExpectations(timeout: 2, handler: nil)
-    }
-    
-    func testMultipleFinallyBlockCanBeRegisteredOnSamePromise() {
-        let finally1 = expectation(description: "finally called")
-        let finally2 = expectation(description: "finally called")
-        let finally3 = expectation(description: "finally called")
-        let finally4 = expectation(description: "finally called")
-        let p = failingFetchUserFollowStatusFromName("")
-        p.finally {
-            finally1.fulfill()
-        }
-        p.finally {
-            finally2.fulfill()
-        }
-        p.finally {
-            finally3.fulfill()
-        }
-        p.finally {
-            finally4.fulfill()
         }
         waitForExpectations(timeout: 2, handler: nil)
     }


### PR DESCRIPTION
We had a need for code to be executed in the middle of a promise chain, without changing the type of the latter.
This code should be running in any case.
A classic example (cheers @maxkonovalov ) would be to update the loading state for instance.

```swift
func fetchNext() -> Promise<[T]> {
    isLoading = true
    call.params["page"] = page + 1
    return call.fetch()
        .registerThen(parseResponse)
        .resolveOnMainThread()
        .noMatterWhat {
            self.isLoading = false
    }
}
```

The naming quite hard to pinpoint

We talked about `registerFinally` but finally does imply 'at the end' which is not really the point in this use case. Another issue that I see is that the current `finally` method can change the type of the promise so this can be misleading to use the same naming with a different behaviour.

ideas:
`anyway` `registerFinally` `noMatterWhat` ...
 
Let me know what you think :)