### PR TITLE
Adding tentative Swift 5 support, relaxing test timing

### DIFF
--- a/Source/Promise+BridgeError.swift
+++ b/Source/Promise+BridgeError.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Promise {
     
-    public func bridgeError(to myError: Error) -> Promise<T> {
+    func bridgeError(to myError: Error) -> Promise<T> {
         let p = newLinkedPromise()
         syncStateWithCallBacks(
             success: p.fulfill,
@@ -21,7 +21,7 @@ public extension Promise {
         return p
     }
     
-    public func bridgeError(_ errorType: Error, to myError: Error) -> Promise<T> {
+    func bridgeError(_ errorType: Error, to myError: Error) -> Promise<T> {
         let p = newLinkedPromise()
         syncStateWithCallBacks(
             success: p.fulfill,
@@ -36,7 +36,7 @@ public extension Promise {
         return p
     }
     
-    public func bridgeError(_ block:@escaping (Error) throws -> Void) -> Promise<T> {
+    func bridgeError(_ block:@escaping (Error) throws -> Void) -> Promise<T> {
         let p = newLinkedPromise()
         syncStateWithCallBacks(
             success: p.fulfill,

--- a/Source/Promise+Delay.swift
+++ b/Source/Promise+Delay.swift
@@ -27,8 +27,9 @@ extension Promise {
 
 extension Promises {
     public static func delay(_ time: TimeInterval) -> Promise<Void> {
-        return Promise { (resolve: @escaping (() -> Void), _: @escaping ((Error) -> Void)) in
-            callBackOnCallingQueueIn(time: time, block: resolve)
+        return Promise { (resolve: @escaping ((()) -> Void), _: @escaping ((Error) -> Void)) in
+            let erasedResolve = { resolve(()) }
+            callBackOnCallingQueueIn(time: time, block: erasedResolve)
         }
     }
 }

--- a/Source/Promise+Error.swift
+++ b/Source/Promise+Error.swift
@@ -10,12 +10,12 @@ import Foundation
 
 public extension Promise {
     
-    @discardableResult public func onError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
+    @discardableResult func onError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
         tryStartInitialPromiseAndStartIfneeded()
         return registerOnError(block)
     }
     
-    @discardableResult public func registerOnError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
+    @discardableResult func registerOnError(_ block: @escaping (Error) -> Void) -> Promise<Void> {
         let p = Promise<Void>()
         passAlongFirstPromiseStartFunctionAndStateTo(p)
         syncStateWithCallBacks(

--- a/Source/Promise+Finally.swift
+++ b/Source/Promise+Finally.swift
@@ -10,12 +10,12 @@ import Foundation
 
 public extension Promise {
     
-    public func finally(_ block: @escaping () -> Void) {
+    func finally(_ block: @escaping () -> Void) {
         tryStartInitialPromiseAndStartIfneeded()
         registerFinally(block)
     }
     
-    public func registerFinally(_ block: @escaping () -> Void) {
+    func registerFinally(_ block: @escaping () -> Void) {
         synchronize { state, blocks in
             switch state {
             case .rejected, .fulfilled:

--- a/Source/Promise+Helpers.swift
+++ b/Source/Promise+Helpers.swift
@@ -9,32 +9,37 @@
 import Foundation
 
 public extension Promise {
-    public class func reject(_ error: Error = PromiseError.default) -> Promise<T> {
+    class func reject(_ error: Error = PromiseError.default) -> Promise<T> {
         return Promise { _, reject in reject(error) }
     }
 }
 
 public extension Promise {
-    public class func resolve(_ value: T) -> Promise<T> {
+    class func resolve(_ value: T) -> Promise<T> {
         return Promise { resolve, _ in resolve(value) }
     }
 }
 
 extension Promise where T == Void {
     public class func resolve() -> Promise<Void> {
-        return Promise { resolve, _ in resolve() }
+
+        let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void)) -> Void)
+                = { resolve, reject in resolve(()) }
+
+        return Promise.init(callback: callback)
+
     }
 }
 
 public extension Promise {
     
-    public var value: T? {
+    var value: T? {
         return synchronize { state, _ in
             return state.value
         }
     }
     
-    public var error: Error? {
+    var error: Error? {
         return synchronize { state, _ in
             return state.error
         }

--- a/Source/Promise+Progress.swift
+++ b/Source/Promise+Progress.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Promise {
     
-    @discardableResult public func progress(_ block: @escaping (Float) -> Void) -> Promise<T> {
+    @discardableResult func progress(_ block: @escaping (Float) -> Void) -> Promise<T> {
         tryStartInitialPromiseAndStartIfneeded()
         let p = newLinkedPromise()
         syncStateWithCallBacks(

--- a/Source/Promise+Then.swift
+++ b/Source/Promise+Then.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public extension Promise {
     
-    @discardableResult public func then<X>(_ block: @escaping (T) -> X) -> Promise<X> {
+    @discardableResult func then<X>(_ block: @escaping (T) -> X) -> Promise<X> {
         let p = registerThen(block)
         tryStartInitialPromiseAndStartIfneeded()
         return p
     }
     
-    @discardableResult public func registerThen<X>(_ block: @escaping (T) -> X) -> Promise<X> {
+    @discardableResult func registerThen<X>(_ block: @escaping (T) -> X) -> Promise<X> {
         let p = Promise<X>()
         
         synchronize { state, blocks in
@@ -42,12 +42,12 @@ public extension Promise {
         return p
     }
     
-    @discardableResult public func then<X>(_ block: @escaping (T) -> Promise<X>) -> Promise<X> {
+    @discardableResult func then<X>(_ block: @escaping (T) -> Promise<X>) -> Promise<X> {
         tryStartInitialPromiseAndStartIfneeded()
         return registerThen(block)
     }
     
-    @discardableResult  public func registerThen<X>(_ block: @escaping (T) -> Promise<X>)
+    @discardableResult  func registerThen<X>(_ block: @escaping (T) -> Promise<X>)
         -> Promise<X> {
             let p = Promise<X>()
             
@@ -72,11 +72,11 @@ public extension Promise {
             return p
     }
     
-    @discardableResult public func then<X>(_ promise: Promise<X>) -> Promise<X> {
+    @discardableResult func then<X>(_ promise: Promise<X>) -> Promise<X> {
         return then { _ in promise }
     }
     
-    @discardableResult public func registerThen<X>(_ promise: Promise<X>) -> Promise<X> {
+    @discardableResult func registerThen<X>(_ promise: Promise<X>) -> Promise<X> {
         return registerThen { _ in promise }
     }
     

--- a/Source/Promise+Zip.swift
+++ b/Source/Promise+Zip.swift
@@ -97,7 +97,7 @@ extension Promises {
         return zip(zip(p1, p2, p3, p4), p5).then { ($0.0, $0.1, $0.2, $0.3, $1) }
     }
     
-    // zip 6
+    // zip 6 swiftlint:disable function_parameter_count
     public static func zip<A, B, C, D, E, F>(_ p1: Promise<A>,
                                              _ p2: Promise<B>,
                                              _ p3: Promise<C>,
@@ -129,4 +129,5 @@ extension Promises {
                                                    _ p8: Promise<H>) -> Promise<(A, B, C, D, E, F, G, H)> {
         return zip(zip(p1, p2, p3, p4, p5, p6, p7), p8).then { ($0.0, $0.1, $0.2, $0.3, $0.4, $0.5, $0.6, $1) }
     }
+    // swiftlint:enable function_parameter_count
 }

--- a/Source/VoidPromise.swift
+++ b/Source/VoidPromise.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Promise where T == Void {
     
     public convenience init(callback: @escaping (
-        _ resolve: @escaping (() -> Void),
+        _ resolve: @escaping ((()) -> Void),
         _ reject: @escaping ((Error) -> Void)) -> Void) {
         self.init()
         setProgressCallBack { resolve, reject, _ in
@@ -20,7 +20,7 @@ extension Promise where T == Void {
     }
     
     public convenience init(callback2: @escaping (
-        _ resolve: @escaping (() -> Void),
+        _ resolve: @escaping ((()) -> Void),
         _ reject: @escaping ((Error) -> Void),
         _ progress: @escaping ((Float) -> Void)) -> Void) {
         self.init()

--- a/then.xcodeproj/project.pbxproj
+++ b/then.xcodeproj/project.pbxproj
@@ -459,7 +459,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = s4cha;
 				TargetAttributes = {
 					17D4C41B1F4703B1002EF805 = {
@@ -482,10 +482,11 @@
 			};
 			buildConfigurationList = 99B5AC911C66831C005CDA28 /* Build configuration list for PBXProject "then" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 99B5AC8D1C66831C005CDA28;
 			productRefGroup = 99B5AC981C66831C005CDA28 /* Products */;
@@ -872,7 +873,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -894,7 +895,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/then.xcodeproj/xcshareddata/xcschemes/then.xcscheme
+++ b/then.xcodeproj/xcshareddata/xcschemes/then.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/then.xcodeproj/xcshareddata/xcschemes/thenMacOS.xcscheme
+++ b/then.xcodeproj/xcshareddata/xcschemes/thenMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/then.xcodeproj/xcshareddata/xcschemes/thenTvOS.xcscheme
+++ b/then.xcodeproj/xcshareddata/xcschemes/thenTvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/thenTests/BridgeErrorTests.swift
+++ b/thenTests/BridgeErrorTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import then
+@testable import then
 
 class BridgeErrorTests: XCTestCase {
     

--- a/thenTests/DelayTests.swift
+++ b/thenTests/DelayTests.swift
@@ -29,7 +29,7 @@ class DelayTests: XCTestCase {
     
     func testDelay() {
         let e = expectation(description: "")
-        var result: Int? = nil
+        var result: Int?
         Promise { resolve, _ in
             waitTime(0.1) {
                 resolve(123)

--- a/thenTests/Helpers.swift
+++ b/thenTests/Helpers.swift
@@ -115,25 +115,35 @@ func waitTime(_ time: Double, callback: @escaping () -> Void) {
 }
 
 func upload() -> Promise<Void> {
-    return Promise { (resolve: @escaping (() -> Void), _: @escaping ((Error) -> Void), progress) in
+
+    let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void), _ progress: @escaping ((Float) -> Void)) -> Void)
+        = { (resolve: @escaping ((()) -> Void), _: @escaping ((Error) -> Void), progress: @escaping ((Float) -> Void)) in
         waitTime {
             progress(0.8)
             waitTime {
-                resolve()
+                resolve(())
             }
         }
+            
     }
+
+    return Promise<Void>(callback2: callback)
 }
 
 func failingUpload() -> Promise<Void> {
-    return Promise { (_: @escaping (() -> Void), reject: @escaping ((Error) -> Void), progress) in
-        waitTime {
-            progress(0.8)
+    
+    let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void), _ progress: @escaping ((Float) -> Void)) -> Void)
+        = { (_: @escaping ((()) -> Void), reject: @escaping ((Error) -> Void), progress: @escaping ((Float) -> Void)) in
             waitTime {
-                reject(NSError(domain: "", code: 1223, userInfo: nil))
+                progress(0.8)
+                waitTime {
+                    reject(NSError(domain: "", code: 1223, userInfo: nil))
+                }
             }
-        }
     }
+
+    
+    return Promise<Void>(callback2: callback)
 }
 
 enum MyError: Error {

--- a/thenTests/RegisterThenTests.swift
+++ b/thenTests/RegisterThenTests.swift
@@ -143,7 +143,7 @@ class RegisterThenTests: XCTestCase {
             .then { _ in
                 timerExpectation.fulfill()
         }
-        waitForExpectations(timeout: 0.3, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testRegisterThenMultipleThenOnlyCallOriginalPromiseOnce() {

--- a/thenTests/RetryTests.swift
+++ b/thenTests/RetryTests.swift
@@ -47,23 +47,31 @@ class RetryTests: XCTestCase {
     }
     
     func testPromise() -> Promise<Void> {
-        return Promise { (_: @escaping (() -> Void), reject: @escaping ((Error) -> Void)) in
+        
+        let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void)) -> Void)
+            = { (resolve: @escaping ((()) -> Void), reject: @escaping ((Error) -> Void)) in
             self.tryCount += 1
             waitTime(0.1) {
                 reject(ARandomError())
             }
         }
+        
+        return Promise<Void>(callback: callback)
     }
     
     func succeedsAfter3Times() -> Promise<Void> {
-        return Promise { (resolve: @escaping (() -> Void), reject: @escaping ((Error) -> Void)) in
-            self.tryCount += 1
-            if self.tryCount == 3 {
-                resolve()
-            } else {
-                reject(ARandomError())
-            }
+        
+        let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void)) -> Void)
+            = { (resolve: @escaping ((()) -> Void), reject: @escaping ((Error) -> Void)) in
+                self.tryCount += 1
+                if self.tryCount == 3 {
+                    resolve(())
+                } else {
+                    reject(ARandomError())
+                }
         }
+        
+        return Promise<Void>(callback: callback)
     }
 }
 

--- a/thenTests/ThenTests.swift
+++ b/thenTests/ThenTests.swift
@@ -28,7 +28,7 @@ class ThenTests: XCTestCase {
         }.finally {
             finallyExpectation.fulfill()
         }
-        waitForExpectations(timeout: 0.3, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testChainedPromises() {

--- a/thenTests/WhenAllTests.swift
+++ b/thenTests/WhenAllTests.swift
@@ -114,9 +114,12 @@ class WhenAllTests: XCTestCase {
             reject(MyError.defaultError)
         }
         
-        let promise2 = Promise<Void> { resolve, _ in
-            resolve()
+        let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void)) -> Void)
+            = { resolve, _ in
+                resolve(())
         }
+        
+        let promise2 = Promise<Void>.init(callback: callback)
         
         Promises.whenAll(promise1, promise2)
             .then { _ in
@@ -137,11 +140,16 @@ class WhenAllTests: XCTestCase {
                 reject(MyError.defaultError)
             }
         }
-        let promise2 = Promise<Void> { resolve, _ in
+        
+        let callback: ((_ resolve: @escaping ((()) -> Void), _ reject: @escaping ((Error) -> Void)) -> Void)
+            = { resolve, _ in
             waitTime(0.1) {
-                resolve()
+                _ = resolve(())
             }
         }
+        
+        let promise2 = Promise<Void>.init(callback: callback)
+        
         Promises.whenAll(promise1, promise2)
             .then { _ in
                 XCTFail("testWhenAllCallsOnErrorWhenOneFailsAsynchronous failed")


### PR DESCRIPTION
Hi, I've begun working on integrating the changes necessary to allow compilation of the project on Xcode 10.2 using its Swift 5 toolchain. 

All tests are currently passing, but I've had to relax the timings on some of them from 0.3 to 0.5 seconds in order to run successfully on simulators. Is that a problem?

Some changes, such as the ones made to Promise<Void> will be breaking the current API, as the compiler can't (any longer?) disambiguate the types on its own. I'm open to ideas on these solutions!