### PR TITLE
Updating Package.swift to work with Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,30 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-  name: "then"
+    name: "then",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "then",
+            targets: ["then"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "then",
+            dependencies: [],
+            path: "Source"),
+        .testTarget(
+            name: "thenTests",
+            dependencies: ["then"],
+            path: "thenTests"),
+    ]
 )


### PR DESCRIPTION
Hey guys, I'm using _then_ in a project with Swift Package Manager. 
I tried to upgrade my project to Swift 5 but I got an error saying that then is using an old version of PackageDescription and Swift tools.

The goal of this PR is just to update the _Package.swift_ file so we won't have any issues like this.

Thanks!