### PR TITLE
Delete too early start before progress block registered

### DIFF
--- a/Source/Promise+Progress.swift
+++ b/Source/Promise+Progress.swift
@@ -11,7 +11,6 @@ import Foundation
 public extension Promise {
     
     @discardableResult public func progress(_ block: @escaping (Float) -> Void) -> Promise<T> {
-        tryStartInitialPromiseAndStartIfneeded()
         let p = newLinkedPromise()
         syncStateWithCallBacks(
             success: p.fulfill,

--- a/thenTests/Helpers.swift
+++ b/thenTests/Helpers.swift
@@ -116,9 +116,11 @@ func waitTime(_ time: Double, callback: @escaping () -> Void) {
 
 func upload() -> Promise<Void> {
     return Promise { (resolve: @escaping (() -> Void), _: @escaping ((Error) -> Void), progress) in
+        progress(0.8)
         waitTime {
             progress(0.8)
             waitTime {
+                progress(0.8)
                 resolve()
             }
         }
@@ -127,9 +129,11 @@ func upload() -> Promise<Void> {
 
 func failingUpload() -> Promise<Void> {
     return Promise { (_: @escaping (() -> Void), reject: @escaping ((Error) -> Void), progress) in
+        progress(0.8)
         waitTime {
             progress(0.8)
             waitTime {
+                progress(0.8)
                 reject(NSError(domain: "", code: 1223, userInfo: nil))
             }
         }


### PR DESCRIPTION
Hi, I'm a stranger who started using this library. I appreciate your effort for this!
This PR is related to issue #50 to let you guys know about what I found.
I'm using tag 4.2.1.
I tried deleting `tryStartInitialPromiseAndStartIfneeded()` from progress(block) function because otherwise progress(float) in Promise may be called before registering the block passed from the progress function. I hope this helps.
Thanks for reading!