### PR TITLE
fix test dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
             dependencies: [],
             path: "Source"),
         .testTarget(
-            name: "thenTests",
+            name: "ThenTests",
             dependencies: ["Then"],
-            path: "thenTests")
+            path: "ThenTests")
     ]
 )


### PR DESCRIPTION
`swift build -c release` was failing with 
'Then' /app/.build/checkouts/then: error: invalid custom path 'thenTests' for target 'thenTests'