### PR TITLE
Changes access level for "setProgress()" function

### DIFF
--- a/Sources/Then/Promise+Progress.swift
+++ b/Sources/Then/Promise+Progress.swift
@@ -25,7 +25,7 @@ public extension Promise {
         return p
     }
     
-    internal func setProgress(_ value: Float) {
+    func setProgress(_ value: Float) {
         updateState(PromiseState<T>.pending(progress: value))
     }
 }


### PR DESCRIPTION
This function is really useful but was set as internal. I propose set as public so everyone can use this.

Use case:
 - You keep the promise in a property or array and need to update the progress via delegate (e.g.: URLSessionTaskDelegate)